### PR TITLE
Fixes #42

### DIFF
--- a/src/events/static/js/events-datepicker.js
+++ b/src/events/static/js/events-datepicker.js
@@ -25,4 +25,9 @@ $(document).ready(function () {
     beforeShowDay: WednesdaysOnly,
 
   });
+    //Open calendar if calendar icon is selected
+	$( "#basic-addon1" ).click(function() {
+      $( "#datepicker" ).focus();
+	});
+
 });


### PR DESCRIPTION
Date picker opens when a student presses on the calender icon